### PR TITLE
Return result from generator; Skip keywords when generating coloring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from platform import python_version
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "textx-gen-coloring"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 AUTHOR = "Daniel Elero"
 AUTHOR_EMAIL = "danixeee@gmail.com"
 DESCRIPTION = "a syntax highlight generator for textX languages"

--- a/textx_gen_coloring/__init__.py
+++ b/textx_gen_coloring/__init__.py
@@ -25,6 +25,7 @@ def textmate_gen(
     debug=False,
     name=None,
     syntax_spec=None,
+    skip_keywords=False,
     silent=False,
 ):
     """Generating textmate syntax highlighting from textX grammars"""
@@ -33,7 +34,7 @@ def textmate_gen(
         click.echo('\nError: Missing option: "--name".')
         sys.exit(1)
 
-    textmate_json = generate_textmate_syntax(model, name, syntax_spec)
+    textmate_json = generate_textmate_syntax(model, name, syntax_spec, skip_keywords)
 
     if output_path:
         if overwrite is False and exists(output_path):

--- a/textx_gen_coloring/__init__.py
+++ b/textx_gen_coloring/__init__.py
@@ -25,6 +25,7 @@ def textmate_gen(
     debug=False,
     name=None,
     syntax_spec=None,
+    silent=False,
 ):
     """Generating textmate syntax highlighting from textX grammars"""
     # Check arguments
@@ -43,4 +44,7 @@ def textmate_gen(
             f.write(textmate_json)
 
     else:
-        click.echo(textmate_json)
+        if not silent:
+            click.echo(textmate_json)
+
+        return textmate_json

--- a/textx_gen_coloring/generators.py
+++ b/textx_gen_coloring/generators.py
@@ -81,7 +81,7 @@ def _parse_syntax_spec(syntax_spec):
     return coloring_mm.model_from_file(syntax_spec)
 
 
-def _parse_grammar(grammar_file, lang_name):
+def _parse_grammar(grammar_file, lang_name, skip_keywords=False):
     """
     Collects information about grammar using textX object processors. Currently
     collects only `StrMatch` rules, since those are language keywords.
@@ -94,16 +94,17 @@ def _parse_grammar(grammar_file, lang_name):
         """Get language keywords (all strings in language grammar definition"""
         grammar_info.keywords.append(str_match.match)
 
-    textx_mm.register_obj_processors(
-        {"StrMatch": partial(_str_obj_processor, grammar_info)}
-    )
+    proccessors = {}
+    if not skip_keywords:
+        proccessors["StrMatch"] = partial(_str_obj_processor, grammar_info)
 
+    textx_mm.register_obj_processors(proccessors)
     textx_mm.model_from_file(grammar_file)
 
     return grammar_info
 
 
-def generate_textmate_syntax(model, lang_name, syntax_spec=None):
+def generate_textmate_syntax(model, lang_name, syntax_spec=None, skip_keywords=False):
     """
     Gets textmate generator depending on provided arguments.
     If syntax specification file is not provided, default generator is used
@@ -112,7 +113,7 @@ def generate_textmate_syntax(model, lang_name, syntax_spec=None):
     grammar_file = model().file_name if callable(model) else model.file_name
     syntax_model = _parse_syntax_spec(syntax_spec) if syntax_spec else None
 
-    grammar_info = _parse_grammar(grammar_file, lang_name)
+    grammar_info = _parse_grammar(grammar_file, lang_name, skip_keywords)
 
     if syntax_model:
         raise NotImplementedError("Not supported yet!")


### PR DESCRIPTION
Following fixes are made for `textX-LS` integration:

- Return result from generator
- Skip keywords when generating coloring