### PR TITLE
Group keyword matches of the same kind + fix for name scope

### DIFF
--- a/textx_gen_coloring/templates/textmate/language.json.template
+++ b/textx_gen_coloring/templates/textmate/language.json.template
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "{{ name }}",
-	"scopeName": "source.{{ name }}",
+	"scopeName": "source.{{ name | lower }}",
 	"patterns": [
         {%- if comment.line != None or (comment.block_start != None and comment.block_end != None) %}
         {


### PR DESCRIPTION
This PR has a simplification of the generated patterns by grouping the patterns of the same scope.
Furthermore, a small fix in scope naming is needed to properly connect the generated syntax file with package.json scope name.